### PR TITLE
update memory allocate check

### DIFF
--- a/src/example/allocate_module.c
+++ b/src/example/allocate_module.c
@@ -21,7 +21,7 @@
 #endif
 #include <sys/types.h>
 
-#if UNIT_TESTING
+//#if UNIT_TESTING
 extern void* _test_malloc(const size_t size, const char* file, const int line);
 extern void* _test_calloc(const size_t number_of_elements, const size_t size,
                           const char* file, const int line);
@@ -30,11 +30,22 @@ extern void _test_free(void* const ptr, const char* file, const int line);
 #define malloc(size) _test_malloc(size, __FILE__, __LINE__)
 #define calloc(num, size) _test_calloc(num, size, __FILE__, __LINE__)
 #define free(ptr) _test_free(ptr, __FILE__, __LINE__)
-#endif // UNIT_TESTING
+//#endif // UNIT_TESTING
 
 void leak_memory() {
     int * const temporary = (int*)malloc(sizeof(int));
     *temporary = 0;
+}
+
+void free_bad_memory() {
+    int counter = 0;
+    free(&counter);
+}
+
+void free_twice_memory() {
+    int* temporary = (int*)malloc(sizeof(int));
+    free(temporary);
+    free(temporary);
 }
 
 void buffer_overflow() {

--- a/src/example/allocate_module_test.c
+++ b/src/example/allocate_module_test.c
@@ -21,11 +21,26 @@
 extern void leak_memory();
 extern void buffer_overflow();
 extern void buffer_underflow();
+extern void free_twice_memory();
+extern void free_bad_memory();
+
 
 // Test case that fails as leak_memory() leaks a dynamically allocated block.
 void leak_memory_test(void **state) {
     leak_memory();
 }
+
+// Test case that fails as free_twice_memory() free twice.
+void free_twice_memory_test(void **state) {
+    free_twice_memory();
+}
+
+// Test case that fails as free_bad_memory() free bad memory.
+void free_bad_memory_test(void **state) {
+    free_bad_memory();
+}
+
+
 
 // Test case that fails as buffer_overflow() corrupts an allocated block.
 void buffer_overflow_test(void **state) {
@@ -42,6 +57,8 @@ int main(int argc, char* argv[]) {
         unit_test(leak_memory_test),
         unit_test(buffer_overflow_test),
         unit_test(buffer_underflow_test),
+        unit_test(free_twice_memory),
+        unit_test(free_bad_memory)
     };
     return run_tests(tests);
 }


### PR DESCRIPTION
If we pass an invalid pointer to _test_free() function, this function will be crashed. So I update this function, add some checking code. Therefore, cmockery can test  cases that free invaild pointer, and free an allocated block twice.