### PR TITLE
Fixes a few compiler warnings.

### DIFF
--- a/src/cmockery.c
+++ b/src/cmockery.c
@@ -1532,7 +1532,7 @@ static LONG WINAPI exception_filter(EXCEPTION_POINTERS *exception_pointers) {
 void vprint_message(const char* const format, va_list args) {
     char buffer[1024];
     vsnprintf(buffer, sizeof(buffer), format, args);
-    printf(buffer);
+    puts(buffer);
 #ifdef _WIN32
     OutputDebugString(buffer);
 #endif // _WIN32
@@ -1542,7 +1542,7 @@ void vprint_message(const char* const format, va_list args) {
 void vprint_error(const char* const format, va_list args) {
     char buffer[1024];
     vsnprintf(buffer, sizeof(buffer), format, args);
-    fprintf(stderr, buffer);
+    fputs(buffer, stderr);
 #ifdef _WIN32
     OutputDebugString(buffer);
 #endif // _WIN32

--- a/src/example/calculator.c
+++ b/src/example/calculator.c
@@ -39,6 +39,8 @@
 
 extern void print_message(const char *format, ...);
 
+extern int example_test_printf(const char *format, ...);
+
 /* Redirect fprintf to a function in the test application so it's possible to
  * test error messages. */
 #ifdef fprintf


### PR DESCRIPTION
printf->puts for non-format strings.
declares the example_test_printf mock predeclaration.