### PR TITLE
Add the possibility of adding a prefix to unit test name

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -88,9 +88,24 @@ void null_test_success(void **state) {
 int main(int argc, char* argv[]) {
     const UnitTest tests[] = {
         unit_test(null_test_success),
+        unit_test_with_prefix(someprefix_, null_test_success),
     };
     return run_tests(tests);
 }
+</listing>
+The prefix can be used to run the same test multiple times and add a prefix
+to the test output.
+This is what the output would look like
+<listing>
+    null_test_success: Starting test
+
+    null_test_success: Test completed successfully.
+
+    someprefix_null_test_success: Starting test
+
+    someprefix_null_test_success: Test completed successfully.
+
+    All 2 tests passed
 </listing>
 
 <a name="Exception_Handling"><h2>Exception Handling</h2></a>

--- a/src/example/run_tests.c
+++ b/src/example/run_tests.c
@@ -25,6 +25,7 @@ void null_test_success(void **state) {
 int main(int argc, char* argv[]) {
     const UnitTest tests[] = {
         unit_test(null_test_success),
+        unit_test_with_prefix(someprefix_, null_test_success),
     };
     return run_tests(tests);
 }

--- a/src/google/cmockery.h
+++ b/src/google/cmockery.h
@@ -244,6 +244,7 @@
 
 // Initializes a UnitTest structure.
 #define unit_test(f) { #f, f, UNIT_TEST_FUNCTION_TYPE_TEST }
+#define unit_test_with_prefix(prefix, f) { #prefix#f, f, UNIT_TEST_FUNCTION_TYPE_TEST }
 #define unit_test_setup(test, setup) \
     { #test "_" #setup, setup, UNIT_TEST_FUNCTION_TYPE_SETUP }
 #define unit_test_teardown(test, teardown) \
@@ -268,6 +269,7 @@
  *     const UnitTest tests[] = {
  *         unit_test(Test0);
  *         unit_test(Test1);
+ *         unit_test_with_prefix(SecondRun_, Test1);
  *     };
  *     return run_tests(tests);
  * }


### PR DESCRIPTION
If the user wants to run the same unit test multiple times
using the macro `unit_test_with_prefix` it is now possible
to differentiate between runs.

This macro appends to the function name what is passed into
the argument
example:
```
unit_test_with_prefix(my_prefix_, some_test_name);
```

will be translated into

`my_prefix_some_test_name`