### PR TITLE
Fix Apache license text to be Apache 2.0 verbatim

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 Google Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Replace LICENSE.txt with the verbatim contents of the Apache 2.0
license, as can be found at the canonical URL:
https://www.apache.org/licenses/LICENSE-2.0.txt

The appendix "How to apply the Apache License to your work." which has a
template copyright line should *NOT* be modified. This license should be
preserved verbatim.

Modifying the license means that GitHub also cannot automatically mark
this repo as being Apache 2.0 licensed; for more info, see this blog
post: https://github.blog/2016-09-21-license-now-displayed-on-repository-overview/

Prior to this change, this repo is marked with "View license" marker to
viewers, which is a bit off-putting as it implies it's using a
non-standard license. With this change, GitHub will display it as
"Apache 2.0".