### PR TITLE
Improve code formatting in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ Contents
 
 To compile the Cmockery library and example applications on Linux, run:
 
-```
+~~~
 $ ./configure
 $ make
-```
+~~~
 
 To compile on Windows, run:
 
-```
+~~~
 > vsvars.bat
 > cd windows
 > nmake
-```
+~~~
 
 This code has been tested on Linux (Ubuntu) and Windows using VC++7 and VC++8.
 
@@ -74,26 +74,27 @@ with the target execution environment.
 
 
 It may not be possible to compile a module into a test application without
-some modification, therefore the preprocessor symbol *UNIT_TESTING* should
+some modification, therefore the preprocessor symbol `UNIT_TESTING` should
 be defined when Cmockery unit test applications are compiled so code within the
 module can be conditionally compiled for tests.
 
 ## <a name="TestExecution"></a>Test Execution
 
 Cmockery unit test cases are functions with the signature
-*void function(void &#42;&#42;state)*.  Cmockery test applications initialize a
-table with test case function pointers using *unit_test&#42;()* macros.  This
-table is then passed to the *run_tests()* macro to execute the tests.
+`void function(void **state)`.  Cmockery test applications initialize a
+table with test case function pointers using `unit_test*()` macros.  This
+table is then passed to the `run_tests()` macro to execute the tests.
 
-*run_tests()* sets up the appropriate exception / signal handlers and
+`run_tests()` sets up the appropriate exception / signal handlers and
 other data structures prior to running each test function.   When a unit test
-is complete *run_tests()* performs various checks to determine whether
+is complete `run_tests()` performs various checks to determine whether
 the test succeeded.
 
-#### <a name="run_tests"></a>Using run_tests()
+#### <a name="run_tests"></a>Using `run_tests()`
 
-[run_tests.c](src/example/run_tests.c)
-~~~
+[`run_tests.c`](src/example/run_tests.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -113,7 +114,7 @@ int main(int argc, char* argv[]) {
 
 ## <a name="ExceptionHandling"></a>Exception Handling
 
-Before a test function is executed by *run_tests()*,
+Before a test function is executed by `run_tests()`,
 exception / signal handlers are overridden with a handler that simply
 displays an error and exits a test function if an exception occurs.  If an
 exception occurs outside of a test function, for example in Cmockery itself,
@@ -122,12 +123,12 @@ the application aborts execution and returns an error code.
 ## <a name="FailureConditions"></a>Failure Conditions
 
 If a failure occurs during a test function that's executed via
-*run_tests()*, the test function is aborted and the application's
+`run_tests()`, the test function is aborted and the application's
 execution resumes with the next test function.
 
-Test failures are ultimately signalled via the Cmockery function *fail()*.
+Test failures are ultimately signalled via the Cmockery function `fail()`.
 The following events will result in the Cmockery library signalling a test
-failure...
+failure:
 
  * [Assertions](#Assertions)
  * [Exceptions](#ExceptionHandling)
@@ -140,19 +141,20 @@ failure...
 
 ## <a name="Assertions"></a>Assertions
 
-Runtime assert macros like the standard C library's *assert()* should
-be redefined in modules being tested to use Cmockery's *mock_assert()*
-function.  Normally *mock_assert()* signals a
+Runtime assert macros like the standard C library's `assert()` should
+be redefined in modules being tested to use Cmockery's `mock_assert()`
+function.  Normally `mock_assert()` signals a
 [test failure](#FailureConditions).  If a function is called using
-the *expect_assert_failure()* macro, any calls to *mock_assert()*
+the `expect_assert_failure()` macro, any calls to `mock_assert()`
 within the function will result in the execution of the test.  If no
-calls to *mock_assert()* occur during the function called via
-*expect_assert_failure()* a test failure is signalled.
+calls to `mock_assert()` occur during the function called via
+`expect_assert_failure()` a test failure is signalled.
 
-#### <a name="mock_assert"></a>Using mock_assert()
+#### <a name="mock_assert"></a>Using `mock_assert()`
 
-[assert_module.c](src/example/assert_module.c)
-~~~
+[`assert_module.c`](src/example/assert_module.c)
+
+~~~c
 #include <assert.h>
 
 // If unit testing is enabled override assert with mock_assert().
@@ -176,9 +178,9 @@ void decrement_value(int * const value) {
 }
 ~~~
 
-[assert_module_test.c](src/example/assert_module_test.c)
+[`assert_module_test.c`](src/example/assert_module_test.c)
 
-~~~
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -219,17 +221,18 @@ Cmockery provides an assortment of assert macros that tests applications
 should use use in preference to the C standard library's assert macro.  On an
 assertion failure a Cmockery assert macro will write the failure to the
 standard error stream and signal a test failure.  Due to limitations of the
-C language the general C standard library assert() and Cmockery's
-assert_true() and assert_false() macros can only display the expression that
+C language the general C standard library `assert()` and Cmockery's
+`assert_true()` and `assert_false()` macros can only display the expression that
 caused the assert failure.  Cmockery's type specific assert macros,
-assert_{type}_equal() and assert_{type}_not_equal(), display the data that
+`assert_{type}_equal()` and `assert_{type}_not_equal()`, display the data that
 caused the assertion failure which increases data visibility aiding
 debugging of failing test cases.
 
-#### <a name="UsingAssertEqualMacros></a>Using assert_{type}_equal() macros
+#### <a name="UsingAssertEqualMacros></a>Using `assert_{type}_equal()` macros
 
-[assert_macro.c](src/example/assert_macro.c)
-~~~
+[`assert_macro.c`](src/example/assert_macro.c)
+
+~~~c
 #include <string.h>
 
 static const char* status_code_strings[] = {
@@ -254,8 +257,9 @@ unsigned int string_to_status_code(const char* const status_code_string) {
 }
 ~~~
 
-[assert_macro_test.c](src/example/assert_macro_test.c)
-~~~
+[`assert_macro_test.c`](src/example/assert_macro_test.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -290,12 +294,12 @@ int main(int argc, char *argv[]) {
 ## <a name="DynamicMemoryAllocation"></a>Dynamic Memory Allocation
 
 To test for memory leaks, buffer overflows and underflows a module being
-tested by Cmockery should replace calls to *malloc()*, *calloc()* and
-*free()* to *test_malloc()*, *test_calloc()* and
-*test_free()* respectively.  Each time a block is deallocated using
-*test_free()* it is checked for corruption, if a corrupt block is found
+tested by Cmockery should replace calls to `malloc()`, `calloc()` and
+`free()` to `test_malloc()`, `test_calloc()` and
+`test_free()` respectively.  Each time a block is deallocated using
+`test_free()` it is checked for corruption, if a corrupt block is found
 a [test failure](#FailureConditions) is signalled.  All blocks
-allocated using the *test_&#42;()* allocation functions are tracked by the
+allocated using the `test_*()` allocation functions are tracked by the
 Cmockery library.  When a test completes if any allocated blocks (memory leaks)
 remain they are reported and a test failure is signalled.
 
@@ -306,8 +310,9 @@ the test application to exit prematurely.
 
 #### <a name="UsingCmockerysAllocators"></a>Using Cmockery's Allocators
 
-[allocate_module.c](src/example/allocate_module.c)
-~~~
+[`allocate_module.c`](src/example/allocate_module.c)
+
+~~~c
 #include <malloc.h>
 
 #if UNIT_TESTING
@@ -338,8 +343,10 @@ void buffer_underflow() {
     free(memory);
 }
 ~~~
-[allocate_module_test.c](src/example/allocate_module_test.c)
-~~~
+
+[`allocate_module_test.c`](src/example/allocate_module_test.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -390,20 +397,21 @@ a mock function defined in the unit test.
 
 In order to simplify the implementation of mock functions Cmockery provides
 functionality which stores return values for mock functions in each test
-case using *will_return()*.  These values are then returned by each mock 
-function using calls to *mock()*.
+case using `will_return()`.  These values are then returned by each mock 
+function using calls to `mock()`.
 
-Values passed to *will_return()* are added to a queue for each function 
-specified.  Each successive call to *mock()* from a function removes a
+Values passed to `will_return()` are added to a queue for each function 
+specified.  Each successive call to `mock()` from a function removes a
 return value from the queue.  This makes it possible for a mock function to use
-multiple calls to *mock()* to return output parameters in addition to a
+multiple calls to `mock()` to return output parameters in addition to a
 return value.  In addition this allows the specification of return values for 
 multiple calls to a mock function.
 
-#### <a name="will_return"></a>Using will_return()
+#### <a name="will_return"></a>Using `will_return()`
 
-[database.h](src/example/database.h)
-~~~
+[`database.h`](src/example/database.h)
+
+~~~c
 typedef struct DatabaseConnection DatabaseConnection;
 
 /* Function that takes an SQL query string and sets results to an array of
@@ -427,8 +435,9 @@ DatabaseConnection* connect_to_database(const char * const url,
                                         const unsigned int port);
 ~~~
 
-[customer_database.c](src/example/customer_database.c)
-~~~
+[`customer_database.c`](src/example/customer_database.c)
+
+~~~c
 #include <stddef.h>
 #include <stdio.h>
 #include <database.h>
@@ -460,8 +469,9 @@ unsigned int get_customer_id_by_name(
 }
 ~~~
 
-[customer_database_test.c](src/example/customer_database_test.c)
-~~~
+[`customer_database_test.c`](src/example/customer_database_test.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -526,20 +536,21 @@ int main(int argc, char* argv[]) {
 
 In addition to storing the return values of mock functions, Cmockery
 provides functionality to store expected values for mock function parameters
-using the expect_`*`() functions provided.  A mock function parameter can then
-be validated using the check_expected() macro.
+using the `expect_*()` functions provided.  A mock function parameter can then
+be validated using the `check_expected()` macro.
 
 
-Successive calls to expect_`*`() macros for a parameter queues values to
-check the specified parameter.  check_expected() checks a function parameter
-against the next value queued using expect_`*`(), if the parameter check fails a
-test failure is signalled.  In addition if check_expected() is called and
+Successive calls to `expect_*()` macros for a parameter queues values to
+check the specified parameter.  `check_expected()` checks a function parameter
+against the next value queued using `expect_*()`, if the parameter check fails a
+test failure is signalled.  In addition if `check_expected()` is called and
 no more parameter values are queued a test failure occurs.
 
-#### <a name="expect"></a>Using expect_`*`()
+#### <a name="expect"></a>Using `expect_*()`
 
-[product_database.c](src/example/product_database.c)
-~~~
+[`product_database.c`](src/example/product_database.c)
+
+~~~c
 #include <database.h>
 
 // Connect to the database containing customer information.
@@ -548,8 +559,9 @@ DatabaseConnection* connect_to_product_database() {
 }
 ~~~
 
-[product_database_test.c](src/example/product_database_test.c)
-~~~
+[`product_database_test.c`](src/example/product_database_test.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -606,17 +618,18 @@ int main(int argc, char* argv[]) {
 ## <a name="TestState"></a>Test State
 
 Cmockery allows the specification of multiple setup and tear down functions
-for each test case.  Setup functions, specified by the *unit_test_setup()*
-or *unit_test_setup_teardown()* macros allow common initialization to be
+for each test case.  Setup functions, specified by the `unit_test_setup()`
+or `unit_test_setup_teardown()` macros allow common initialization to be
 shared between multiple test cases.  In addition, tear down functions,
-specified by the *unit_test_teardown()* or
-*unit_test_setup_teardown()* macros provide a code path that is always
+specified by the `unit_test_teardown()` or
+`unit_test_setup_teardown()` macros provide a code path that is always
 executed for a test case even when it fails.
 
-#### <a name="unit_test_setup_teardown"></a>Using unit_test_setup_teardown()
+#### <a name="unit_test_setup_teardown"></a>Using `unit_test_setup_teardown()`
 
-[key_value.c](src/example/key_value.c)
-~~~
+[`key_value.c`](src/example/key_value.c)
+
+~~~c
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -658,8 +671,9 @@ void sort_items_by_key() {
 }
 ~~~
 
-[key_value_test.c](src/example/key_value_test.c)
-~~~
+[`key_value_test.c`](src/example/key_value_test.c)
+
+~~~c
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -730,7 +744,7 @@ int main(int argc, char* argv[]) {
 ## <a name="Example"></a>Example
 
 A small command line calculator
-[calculator.c](src/example/calculator.c) application
+[`calculator.c`](src/example/calculator.c) application
 and test application that full exercises the calculator application
-[calculator_test.c](src/example/calculator_test.c)
+[`calculator_test.c`](src/example/calculator_test.c)
 are provided as an example of Cmockery's features discussed in this document.


### PR DESCRIPTION
* Use backticks to format code inline instead of asterisks, which are
  interpreted as italics in Markdown
* This helps us remove the `&#42;` HTML entities which were used to
  create asterisks within asterisks-surrounded regions for C pointers,
  making the text much more readable
* Added backticks around filenames and function names in headings, which
  improves readability in the README, and avoids confusing Markdown
  parsers in editors which highlight regions of text as italics
  (underscores also create italicized text) when it is not intended
* Annotate all code samples as C code to get syntax highlighting, making
  code samples much easier to read