### PR TITLE
Fix the build, broken due to recent text file changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
 ## This is for HTML and other documentation you want to install.
 ## Add your documentation files (in doc/) in addition to these
 ## top-level boilerplate files.  Also add a TODO file if you have one.
-dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README doc/index.html \
+dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README doc/index.html \
 		windows/makefile
 
 ## The libraries (.so's) you want to install

--- a/Makefile.in
+++ b/Makefile.in
@@ -45,7 +45,7 @@ noinst_PROGRAMS = calculator$(EXEEXT) calculator_test$(EXEEXT) \
 	customer_database_test$(EXEEXT) key_value_test$(EXEEXT) \
 	product_database_test$(EXEEXT) run_tests$(EXEEXT) \
 	$(am__EXEEXT_1)
-DIST_COMMON = README $(am__configure_deps) $(dist_doc_DATA) \
+DIST_COMMON = README.md $(am__configure_deps) $(dist_doc_DATA) \
 	$(googleinclude_HEADERS) $(srcdir)/Makefile.am \
 	$(srcdir)/Makefile.in $(top_srcdir)/configure \
 	$(top_srcdir)/src/config.h.in AUTHORS COPYING ChangeLog \
@@ -263,7 +263,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 googleincludedir = $(includedir)/google
 googleinclude_HEADERS = src/google/cmockery.h
 docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
-dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README doc/index.html
+dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README.md doc/index.html
 lib_LTLIBRARIES = libcmockery.la
 TESTS = 
 TESTS_ENVIRONMENT = CMOCKERY_ROOTDIR = $(top_srcdir)

--- a/Makefile.in
+++ b/Makefile.in
@@ -48,7 +48,7 @@ noinst_PROGRAMS = calculator$(EXEEXT) calculator_test$(EXEEXT) \
 DIST_COMMON = README.md $(am__configure_deps) $(dist_doc_DATA) \
 	$(googleinclude_HEADERS) $(srcdir)/Makefile.am \
 	$(srcdir)/Makefile.in $(top_srcdir)/configure \
-	$(top_srcdir)/src/config.h.in AUTHORS COPYING ChangeLog \
+	$(top_srcdir)/src/config.h.in AUTHORS LICENSE.txt ChangeLog \
 	INSTALL NEWS compile config.guess config.sub depcomp \
 	install-sh ltmain.sh missing mkinstalldirs
 subdir = .
@@ -263,7 +263,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 googleincludedir = $(includedir)/google
 googleinclude_HEADERS = src/google/cmockery.h
 docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
-dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README.md doc/index.html
+dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README.md doc/index.html
 lib_LTLIBRARIES = libcmockery.la
 TESTS = 
 TESTS_ENVIRONMENT = CMOCKERY_ROOTDIR = $(top_srcdir)

--- a/configure
+++ b/configure
@@ -427,7 +427,7 @@ PACKAGE_VERSION='0.11'
 PACKAGE_STRING='cmockery 0.11'
 PACKAGE_BUGREPORT='opensource@google.com'
 
-ac_unique_file="README"
+ac_unique_file="README.md"
 # Factoring default headers for most tests.
 ac_includes_default="\
 #include <stdio.h>

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_PREREQ(2.57)
 AC_INIT(cmockery, 0.1.2, opensource@google.com)
 # The argument here is just something that should be in the current directory
 # (for sanity checking)
-AC_CONFIG_SRCDIR(README)
+AC_CONFIG_SRCDIR(README.md)
 AM_INIT_AUTOMAKE
 AM_CONFIG_HEADER(src/config.h)
 


### PR DESCRIPTION
The following previous changes:

* [removing the `README` file][readme] and merging it into the `readme.md` file, as well as
* [removing the `COPYING` file][readme] since it conflicted with the `LICENSE.txt` file

had the unintended effect that it broke the build in several ways.

These changes update the relevant files to enable the `./configure && make` steps to work again.

[readme]: https://github.com/google/cmockery/pull/44
[copying]: https://github.com/google/cmockery/issues/16