### PR TITLE
Add Travis CI badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Cmockery Unit Testing Framework
 
+[![Build Status][travis-badge]][travis-url]
+
+[travis-badge]: https://travis-ci.org/google/cmockery.svg?branch=master
+[travis-url]: https://travis-ci.org/google/cmockery
+
 Cmockery is a lightweight library that is used to author C unit tests.
 
 Contents


### PR DESCRIPTION
This CL doesn't have `[skip ci]` so that we can explicitly exercise the Travis CI config added in
PR https://github.com/google/cmockery/pull/48 .