### PR TITLE
Fix build: remove references to doc/index.html

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
 ## This is for HTML and other documentation you want to install.
 ## Add your documentation files (in doc/) in addition to these
 ## top-level boilerplate files.  Also add a TODO file if you have one.
-dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README doc/index.html \
+dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README \
 		windows/makefile
 
 ## The libraries (.so's) you want to install

--- a/Makefile.in
+++ b/Makefile.in
@@ -263,7 +263,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 googleincludedir = $(includedir)/google
 googleinclude_HEADERS = src/google/cmockery.h
 docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
-dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README.md doc/index.html
+dist_doc_DATA = AUTHORS LICENSE.txt ChangeLog INSTALL NEWS README.md
 lib_LTLIBRARIES = libcmockery.la
 TESTS = 
 TESTS_ENVIRONMENT = CMOCKERY_ROOTDIR = $(top_srcdir)


### PR DESCRIPTION
`doc/index.html` was a stale file, thought to be unused, which was
removed in PR #52 to fix issue #50. That PR ended up breaking the build
because the file was actually referenced from `Makefile.in` and
`Makefile.am`.

This fixes issue #57.