### PR TITLE
Add Arm64 builds, upgrade to Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dist: xenial
+dist: bionic
 sudo: false
 language: c
 
 matrix:
   include:
     - os: linux
+      arch: amd64
       compiler: gcc
     - os: linux
+      arch: amd64
+      compiler: clang
+    - os: linux
+      arch: arm64
+      compiler: gcc
+    - os: linux
+      arch: arm64
       compiler: clang
     - os: osx
+
+  allow_failures:
+    - arch: arm64
+    - os: osx
+
+  fast_finish: true
+
+branches:
+  only:
+    - master
 
 script:
   - ./configure && make


### PR DESCRIPTION
* use the new Arm64 builds available on Travis CI:
  https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support
* allow the build to pass quickly as soon as Linux builds pass
* allow macOS build to fail (e.g., due to lack of resources)
* build only on the `master` branch, and not any feature branches
* update from `xenial` (Ubuntu 16.04) to `bionic` (Ubuntu 18.04)